### PR TITLE
feat: Add GitHub Actions workflow for CI and GitHub Pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: Build, Test, and Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build application
+        run: npm run build
+
+      - name: Run tests
+        run: npm run test
+
+  deploy-to-pages:
+    runs-on: ubuntu-latest
+    needs: build-and-test # This job depends on the build-and-test job
+    permissions:
+      pages: write # GITHUB_TOKEN needs permission to write to gh-pages
+      id-token: write # GITHUB_TOKEN needs permission to create an OIDC token
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }} # URL to the deployed page
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build application for GitHub Pages
+        env:
+          # This will be used to set the base path in vite.config.ts
+          # The value is the repository name, which is needed for GitHub Pages
+          BASE_URL: ${{ github.event.repository.name }}
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/client
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 import { reactRouter } from "@react-router/dev/vite";
 import tailwindcss from "@tailwindcss/vite";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
-export default defineConfig({
-  plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
+export default defineConfig(({ mode }) => {
+  // Load env file based on mode (development, production, etc.)
+  const env = loadEnv(mode, process.cwd(), ''); // Load all env variables
+
+  return {
+    plugins: [tailwindcss(), reactRouter(), tsconfigPaths()],
+    base: env.BASE_URL || "/", // Set base path from BASE_URL env var, default to '/'
+  };
 });


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow that automates the build, test, and deployment process of the SPA.

Key changes:
- Added `.github/workflows/ci.yml`:
    - Triggers on pushes to the `main` branch.
    - Includes a `build-and-test` job that installs dependencies, builds the application, and runs `vitest` tests.
    - Includes a `deploy-to-pages` job that depends on the `build-and-test` job. This job builds the application with a dynamic base URL (repository name) and deploys the `build/client` directory to GitHub Pages using `actions/deploy-pages`.
- Updated `vite.config.ts`:
    - Modified to dynamically set the `base` path for Vite.
    - It now uses the `BASE_URL` environment variable if set (for GitHub Pages deployment) or defaults to `/` for local development.
